### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:2
+
+COPY . /usr/src/elasticstat/
+WORKDIR /usr/src/elasticstat/
+
+RUN pip install --no-cache .
+
+ENTRYPOINT [ "python", "./elasticstat/elasticstat.py" ]
+CMD [ "--help" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2
+FROM python:2-slim
 
 COPY . /usr/src/elasticstat/
 WORKDIR /usr/src/elasticstat/


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official Python image, `:2` tag. More info at https://hub.docker.com/_/python/

Just adding files, setting working dir and running install.

Build:

```
$ docker build -t elasticstat .
```

Run:

```
$ docker run --rm -it elasticstat [options...]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it pataquets/elasticstat-src [options...]
```

Should stop by `CTRL+C`'ing it.
If no options given, assume `--help`to avoid any error message.

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed. Useful as an easy direct-from-source (branches and tags) distribution method and for having a 'daily' build from source on each commit.