### PR TITLE
Es7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [1.3.4] - 2020-1-15 Paul Rossmeier
+### Added
+* requirements.txt
+* elasticstat/elasticstat.py - added version discovery to (_parse_threadpools) - updates threadpool to match version above or below 7
+* elasticstat/elasticstat.py - added packages "json", "re", "packaging" to the import commands
+* elasticstat/elasticstat.py - added "write" to the defailt threadpool
+###Changed
+* elasticstat/elasticstat.py -  moving self.threadpool constructor after client creation constructor to use version discovery
+* setup.py -  added packaging and certifi to 'install_requires'

--- a/README2.md
+++ b/README2.md
@@ -1,0 +1,1 @@
+this is an update to ES 7 - updating the index/bulk to write

--- a/README2.md
+++ b/README2.md
@@ -1,1 +1,0 @@
-this is an update to ES 7 - updating the index/bulk to write

--- a/elasticstat/__init__.py
+++ b/elasticstat/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'Jeff Tharp'
-__version__ = '1.3.3'
+__version__ = '1.3.4'

--- a/elasticstat/elasticstat.py
+++ b/elasticstat/elasticstat.py
@@ -164,13 +164,13 @@ class Elasticstat:
         return ['general'] + categories
 
     def _parse_threadpools(self, threadpools):
-        #adding version discovery for ES7 to get correct threadpool
+        # adding version discovery for ES7 to get correct threadpool
         if version.parse(json.dumps(self.es_client.info()['version']['number']).strip('"')) > version.parse("7.0.0"):
             threadpools = filter(None, [re.sub(r".*index*", r"", i) for i in threadpools])
             threadpools = filter(None, [re.sub(r".*bulk*", r"", i) for i in threadpools])
         else:
             threadpools = filter(None, [re.sub(r".*write*", r"", i) for i in threadpools])
-        #end vesion discovery
+        # end vesion discovery
         if isinstance(threadpools, list) and ',' in threadpools[0]:
             threadpools = threadpools[0].split(',')
         return threadpools

--- a/elasticstat/elasticstat.py
+++ b/elasticstat/elasticstat.py
@@ -114,7 +114,7 @@ class Elasticstat:
         # Create Elasticsearch client
         self.es_client = Elasticsearch(self._parse_connection_properties(args.hostlist, args.port, args.username,
                                                                          args.password, args.use_ssl))
-        #moving threadpool after client creation to use version discovery
+        # moving threadpool after client creation to use version discovery
         self.threadpools = self._parse_threadpools(args.threadpools)
 
     def _parse_connection_properties(self, host, port, username, password, use_ssl):
@@ -170,7 +170,7 @@ class Elasticstat:
             threadpools = filter(None, [re.sub(r".*bulk*", r"", i) for i in threadpools])
         else:
             threadpools = filter(None, [re.sub(r".*write*", r"", i) for i in threadpools])
-        #end vesion dicscovery
+        #end vesion discovery
         if isinstance(threadpools, list) and ',' in threadpools[0]:
             threadpools = threadpools[0].split(',')
         return threadpools

--- a/elasticstat/elasticstat.py
+++ b/elasticstat/elasticstat.py
@@ -21,7 +21,10 @@ import getpass
 import signal
 import sys
 import time
+import json
+import re
 
+from packaging import version
 from elasticsearch import Elasticsearch
 from urllib3.util import parse_url
 
@@ -67,7 +70,7 @@ NODE_HEADINGS["merge_time"] = "merges"
 NODE_HEADINGS["store_throttle"] = "idx st"
 NODE_HEADINGS["docs"] = "docs"
 NODE_HEADINGS["fs"] = "disk usage"
-DEFAULT_THREAD_POOLS = ["index", "search", "bulk", "get"]
+DEFAULT_THREAD_POOLS = ["index", "search", "bulk", "get", "write"]
 CATEGORIES = ['general', 'os', 'jvm', 'threads', 'fielddata', 'connections', 'data_nodes']
 
 class ESArgParser(argparse.ArgumentParser):
@@ -102,7 +105,6 @@ class Elasticstat:
         self.new_nodes = [] # used to track new nodes that join the cluster
         self.active_master = ""
         self.no_color = args.no_color
-        self.threadpools = self._parse_threadpools(args.threadpools)
         self.categories = self._parse_categories(args.categories)
         self.cluster_categories = CLUSTER_CATEGORIES
         if args.no_pending_tasks:
@@ -112,6 +114,8 @@ class Elasticstat:
         # Create Elasticsearch client
         self.es_client = Elasticsearch(self._parse_connection_properties(args.hostlist, args.port, args.username,
                                                                          args.password, args.use_ssl))
+        #moving threadpool after client creation to use version discovery
+        self.threadpools = self._parse_threadpools(args.threadpools)
 
     def _parse_connection_properties(self, host, port, username, password, use_ssl):
         hosts_list = []
@@ -160,6 +164,13 @@ class Elasticstat:
         return ['general'] + categories
 
     def _parse_threadpools(self, threadpools):
+        #adding version discovery for ES7 to get correct threadpool
+        if version.parse(json.dumps(self.es_client.info()['version']['number']).strip('"')) > version.parse("7.0.0"):
+            threadpools = filter(None, [re.sub(r".*index*", r"", i) for i in threadpools])
+            threadpools = filter(None, [re.sub(r".*bulk*", r"", i) for i in threadpools])
+        else:
+            threadpools = filter(None, [re.sub(r".*write*", r"", i) for i in threadpools])
+        #end vesion dicscovery
         if isinstance(threadpools, list) and ',' in threadpools[0]:
             threadpools = threadpools[0].split(',')
         return threadpools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 certifi==2019.11.28
 elasticsearch==7.1.0
-elasticstat==1.3.3
 packaging==20.0
 pyparsing==2.4.6
 six==1.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+certifi==2019.11.28
+elasticsearch==7.1.0
+elasticstat==1.3.3
+packaging==20.0
+pyparsing==2.4.6
+six==1.13.0
+urllib3==1.25.7

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='jtharp@objectrocket.com',
     url = 'https://github.com/objectrocket/elasticstat',
     download_url = 'https://github.com/objectrocket/elasticstat/archive/1.3.0.tar.gz',
-    install_requires=['elasticsearch'],
+    install_requires=['elasticsearch', 'packaging', 'certifi'],
     packages=['elasticstat'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
ES changed the threadpools in version7 - the "index" and "bulk" were combined to a "write" threadpool
https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#_index_thread_pool

Elasticstat takes a command line arg that you can define the threadapool - if you dont - then you get the default 

`DEFAULT_THREAD_POOLS = ["index", "search", "bulk", "get"]`

I updated DEFAULT_THREAD_POOLS to 

`DEFAULT_THREAD_POOLS = ["index", "search", "bulk", "get", "write"]`

I added version discovery to method "_parse_threadpools()" (added the "version" method from the packages library, added an import for both json and re standard libraries) and then stripped ["index","bulk"] from versions 7 and above and stripped ["write"] from all versions that are below 7

I had to move the constructor for the threadpools 

`self.threadpools = self._parse_threadpools(args.threadpools)`

below the client constructor so I could use the es_client for the version discovery


Result is the correct threadpools for the correct ES version