### PR TITLE
Dockerfile: Download requirements in separate build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM python:2-slim
 
-COPY . /usr/src/elasticstat/
 WORKDIR /usr/src/elasticstat/
 
+COPY ./requirements/prod.txt /usr/src/elasticstat/requirements/
+RUN pip install --no-cache -r ./requirements/prod.txt
+
+COPY . /usr/src/elasticstat/
 RUN pip install --no-cache .
 
 ENTRYPOINT [ "python", "./elasticstat/elasticstat.py" ]


### PR DESCRIPTION
Speeds up repeated builds while coding by taking advantage of Docker image layer caching. Does not increase resulting image size.

Try it:
* Do `docker build -t elasticstat .`
* Change any single file from the source tree.
* Build again. Dependency tarballs are downloaded every time.

If build is split in different steps, there are no downloads (unless you modify `prod.txt`).